### PR TITLE
Don't try to validate a null folder name.

### DIFF
--- a/src/model/user-script-observer.ts
+++ b/src/model/user-script-observer.ts
@@ -49,6 +49,11 @@ export class UserScriptObserver {
         return;
       }
 
+
+      if (s.userScriptFolder == null) {
+        return
+      }
+
       const valid = await this.vault.adapter.exists(s.userScriptFolder);
       if (!valid) {
         return;

--- a/src/view/explorer/ProjectPicker.svelte
+++ b/src/view/explorer/ProjectPicker.svelte
@@ -60,6 +60,7 @@
 <div id="project-picker-container">
   {#if projectOptions.length > 0}
     <div id="project-picker">
+    <label for="select-projects">Project:&nbsp;</label>
       <div class="select" id="select-projects">
         <select
           name="projects"


### PR DESCRIPTION
First change eliminates a recurring exception in the debugger for userScriptFolder being null. 

Second adds a label to the project picker. It was immediately obvious to me that the path at the top of the panel was selectable. Text could say "select project", but that might be too wide?
