### PR TITLE
fix: calculate word count diff for new scenes in a session, fixes #93

### DIFF
--- a/src/model/writing-session-tracker.ts
+++ b/src/model/writing-session-tracker.ts
@@ -341,7 +341,7 @@ export class WritingSessionTracker {
             typeof startCount === "object" ? startCount[scene] ?? null : null;
           const diff = startSceneCount
             ? Math.max(sceneCount - startSceneCount, 0)
-            : 0;
+            : sceneCount;
           const startDiffScene = startDiff?.scenes[scene] ?? 0;
           const sceneTotal = withDeletions(
             startDiffScene + diff,


### PR DESCRIPTION
I believe this fixes issue #93.

To repro the bug:

1. Open existing Longform project and create a new scene
1. Type words into the new scene

**Expected**: Word count will be added to the current session total
**Actual:** New words are ignored

I debugged the plugin using the test vault and noticed that for new scenes, the `startSceneCount` in the `WritingSessionTracker.tickSession` method always ended up as null, which would cause the `diff` variable to be set to 0. My fix is to just return the `sceneCount` for this case.

I think this is the root cause to #93, I did test using copy/paste and it seems to be fine, but I also only reviewed the code base for a few hours, so I could be missing something. This does resolve the session word count issue I've been running into though.
