### PR TITLE
fix: unify messaging in-app with docs

### DIFF
--- a/src/view/explorer/ProjectPicker.svelte
+++ b/src/view/explorer/ProjectPicker.svelte
@@ -91,8 +91,9 @@
     {/if}
   {:else}
     <p>
-      To use Longform, start by marking a folder as a Longform project by
-      right-clicking it and selecting "Mark as Longform project."
+      To begin, find or create a folder somewhere in your vault in which 
+      you would like to create your novel. Right-click it and select 
+      <code>Create Longform Project.</code>
     </p>
   {/if}
 </div>


### PR DESCRIPTION
Very simple fix to make the "get started with longform" messaging within the plugin match what the documentation says (and how the plugin actually behaves).

Something to note, I was unable to build for production due to a few linting errors.  However, I tested it in the test-longform-vault with the dev build, and it looks ok (once I deleted all the longform projects in there to get the new messaging).

![Capture](https://github.com/kevboh/longform/assets/50385408/6df2b881-56dd-4a76-8c74-a564e140ac1e)

Should fix #182 