### PR TITLE
Fix external link regex

### DIFF
--- a/src/compile/steps/remove-links.ts
+++ b/src/compile/steps/remove-links.ts
@@ -11,7 +11,7 @@ import {
 } from "./abstract-compile-step";
 
 const WIKILINKS_REGEX = /\[\[([^[|]+)(|[^[]+)?\]\]/gm;
-const EXTERNAL_LINKS_REGEX = /\[([^[]+)\](\(.*\))/gm;
+const EXTERNAL_LINKS_REGEX = /\[([^[]+)\](\(.*?\))/gm;
 
 export const RemoveLinksStep = makeBuiltinStep({
   id: "remove-links",

--- a/test/compile/steps/remove-links.test.ts
+++ b/test/compile/steps/remove-links.test.ts
@@ -23,6 +23,8 @@ describe("Removing Links", () => {
             .toEqual("Filename\nOther Filename")
         expect(replaceExternalLinks("[Alias](Some/Path/To/Filename.md)")).toEqual("Alias")
         expect(replaceExternalLinks("[Alias](Some/Path/To/Filename.md#^blockId)")).toEqual("Alias")
+        expect(replaceExternalLinks("[Filename] (Some/Path/To/Filename.md)")).toEqual("[Filename] (Some/Path/To/Filename.md)")
+        expect(replaceExternalLinks("[Filename Some/Path/To/Filename.md)")).toEqual("[Filename Some/Path/To/Filename.md)")
     })
 
     it("does not remove embeds", () => {
@@ -30,6 +32,9 @@ describe("Removing Links", () => {
         expect(replaceWikiLinks("![[Filename]][[Other filename]]")).toEqual("![[Filename]]Other filename")
         expect(replaceWikiLinks("[[Filename]]![[Other filename]]")).toEqual("Filename![[Other filename]]")
 
+        expect(replaceExternalLinks("![Filename](Some/Path/To/Filename.md)")).toEqual("![Filename](Some/Path/To/Filename.md)")
+        expect(replaceExternalLinks("![Filename](Some/Path/To/Filename.md)[Filename](Some/Path/To/Filename.md)")).toEqual("![Filename](Some/Path/To/Filename.md)Filename")
+        expect(replaceExternalLinks("[Filename](Some/Path/To/Filename.md)![Filename](Some/Path/To/Filename.md)")).toEqual("Filename![Filename](Some/Path/To/Filename.md)")
     })
 
 })

--- a/test/compile/steps/remove-links.test.ts
+++ b/test/compile/steps/remove-links.test.ts
@@ -4,11 +4,14 @@ import { replaceWikiLinks, replaceExternalLinks } from 'src/compile/steps/remove
 describe("Removing Links", () => {
 
     it("removes wiki links", () => {
+        expect(replaceWikiLinks("[[]]")).toEqual("[[]]")
+        expect(replaceWikiLinks("[[link]] followed by a single end bracket]")).toEqual("link followed by a single end bracket]")
         expect(replaceWikiLinks("[[Filename]]")).toEqual("Filename")
         expect(replaceWikiLinks("[[Filename]] and [[other filename]]")).toEqual("Filename and other filename")
         expect(replaceWikiLinks("[[Filename]]\n[[Other filename]]")).toEqual("Filename\nOther filename")
         expect(replaceWikiLinks("[[Filename|Alias]]")).toEqual("Alias")
         expect(replaceWikiLinks("[[Filename#^blockId|Alias]]")).toEqual("Alias")
+        expect(replaceWikiLinks("[[Filename#^blockId]]")).toEqual("Filename#^blockId")
         expect(replaceWikiLinks("[[Some/Path/To/Filename|Filename]]")).toEqual("Filename")
     })
 
@@ -20,6 +23,13 @@ describe("Removing Links", () => {
             .toEqual("Filename\nOther Filename")
         expect(replaceExternalLinks("[Alias](Some/Path/To/Filename.md)")).toEqual("Alias")
         expect(replaceExternalLinks("[Alias](Some/Path/To/Filename.md#^blockId)")).toEqual("Alias")
+    })
+
+    it("does not remove embeds", () => {
+        expect(replaceWikiLinks("![[Filename]]")).toEqual("![[Filename]]")
+        expect(replaceWikiLinks("![[Filename]][[Other filename]]")).toEqual("![[Filename]]Other filename")
+        expect(replaceWikiLinks("[[Filename]]![[Other filename]]")).toEqual("Filename![[Other filename]]")
+
     })
 
 })

--- a/test/compile/steps/remove-links.test.ts
+++ b/test/compile/steps/remove-links.test.ts
@@ -4,8 +4,6 @@ import { replaceWikiLinks, replaceExternalLinks } from 'src/compile/steps/remove
 describe("Removing Links", () => {
 
     it("removes wiki links", () => {
-        expect(replaceWikiLinks("[[]]")).toEqual("[[]]")
-        expect(replaceWikiLinks("[[link]] followed by a single end bracket]")).toEqual("link followed by a single end bracket]")
         expect(replaceWikiLinks("[[Filename]]")).toEqual("Filename")
         expect(replaceWikiLinks("[[Filename]] and [[other filename]]")).toEqual("Filename and other filename")
         expect(replaceWikiLinks("[[Filename]]\n[[Other filename]]")).toEqual("Filename\nOther filename")
@@ -13,6 +11,9 @@ describe("Removing Links", () => {
         expect(replaceWikiLinks("[[Filename#^blockId|Alias]]")).toEqual("Alias")
         expect(replaceWikiLinks("[[Filename#^blockId]]")).toEqual("Filename#^blockId")
         expect(replaceWikiLinks("[[Some/Path/To/Filename|Filename]]")).toEqual("Filename")
+        expect(replaceWikiLinks("[[]]")).toEqual("[[]]")
+        expect(replaceWikiLinks("[[link]] followed by a single end bracket]")).toEqual("link followed by a single end bracket]")
+        expect(replaceWikiLinks("[[Filename|Alias|OtherAlias|Another Alias]]")).toEqual("AliasOtherAliasAnother Alias")
     })
 
     it("removes external links", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules/*"],
   "compilerOptions": {
     "baseUrl": ".",


### PR DESCRIPTION
External link regex was greedily capturing any character except newlines 
This small change makes it capture as few characters as possible

fix #189