### PR TITLE
Handle missing scene folder

### DIFF
--- a/src/model/note-utils.ts
+++ b/src/model/note-utils.ts
@@ -17,8 +17,26 @@ export async function createNoteWithPotentialTemplate(
   path: string,
   template: string | null
 ): Promise<void> {
-  const file = await app.vault.create(path, "");
-  if (template) {
+  const pathComponents = path.split("/");
+  pathComponents.pop();
+
+  if (!(await app.vault.adapter.exists(pathComponents.join("/")))) {
+    try {
+      await app.vault.createFolder(pathComponents.join("/"));
+    } catch (e) {
+      console.error(`[Longform] Failed to create new note at "${path}"`, e)
+      return;
+    }
+  }
+
+  let file: TFile | null = null;
+  try {
+    file = await app.vault.create(path, "");
+  } catch(e: unknown) {
+    console.error(`[Longform] Failed to create new note at "${path}"`, e)
+    return;
+  }
+  if (template && file) {
     let contents = "";
     let pluginUsed = "";
     try {

--- a/src/model/note-utils.ts
+++ b/src/model/note-utils.ts
@@ -17,25 +17,7 @@ export async function createNoteWithPotentialTemplate(
   path: string,
   template: string | null
 ): Promise<void> {
-  const pathComponents = path.split("/");
-  pathComponents.pop();
-
-  if (!(await app.vault.adapter.exists(pathComponents.join("/")))) {
-    try {
-      await app.vault.createFolder(pathComponents.join("/"));
-    } catch (e) {
-      console.error(`[Longform] Failed to create new note at "${path}"`, e)
-      return;
-    }
-  }
-
-  let file: TFile | null = null;
-  try {
-    file = await app.vault.create(path, "");
-  } catch(e: unknown) {
-    console.error(`[Longform] Failed to create new note at "${path}"`, e)
-    return;
-  }
+  const file = await createNote(path);
   if (template && file) {
     let contents = "";
     let pluginUsed = "";
@@ -53,6 +35,37 @@ export async function createNoteWithPotentialTemplate(
     if (contents !== "") {
       await app.vault.adapter.write(path, contents);
     }
+  }
+}
+
+/**
+ * Creates a note at `path` with the given `initialContent`.
+ * @param path 
+ * @param initialContent 
+ * @returns `null` if it fails to create the note.  `TFile` for the new note, if successful.
+ */
+export async function createNote(path: string, initialContent: string = ""): Promise<TFile | null> {
+  const pathComponents = path.split("/");
+  pathComponents.pop();
+
+  if (!(await app.vault.adapter.exists(pathComponents.join("/")))) {
+    try {
+      await app.vault.createFolder(pathComponents.join("/"));
+    } catch (e) {
+      console.error(`[Longform] Failed to create new note at "${path}"`, e)
+      return null;
+    }
+  }
+
+  try {
+    // as of obsidian 1.4.4, vault.create will successfully create a file, and
+    // its parent folder, but will throw an error anyway, if the parent folder
+    // didn't initially exist.  By creating the parent folder above, we avoid 
+    // that situation.  This may change in later versions of obsidian.
+    return await app.vault.create(path, initialContent);
+  } catch(e: unknown) {
+    console.error(`[Longform] Failed to create new note at "${path}"`, e)
+    return null;
   }
 }
 

--- a/src/model/store-vault-sync.ts
+++ b/src/model/store-vault-sync.ts
@@ -396,11 +396,15 @@ export class StoreVaultSync {
         `${fileWithMetadata.file.parent.path}/${sceneFolder}`
       );
 
-      const filenamesInSceneFolder = (
-        await this.vault.adapter.list(normalizedSceneFolder)
-      ).files
-        .filter((f) => f !== fileWithMetadata.file.path && f.endsWith(".md"))
-        .map((f) => this.vault.getAbstractFileByPath(f).name.slice(0, -3));
+      let filenamesInSceneFolder: string[] = [];
+      if (await this.vault.adapter.exists(normalizedSceneFolder)) {
+        filenamesInSceneFolder = (
+          await this.vault.adapter.list(normalizedSceneFolder)
+        ).files
+          .filter((f) => f !== fileWithMetadata.file.path && f.endsWith(".md"))
+          .map((f) => this.vault.getAbstractFileByPath(f)?.name.slice(0, -3))
+          .filter(maybeName => maybeName !== null && maybeName !== undefined) as string[];
+      }  
 
       // Filter removed scenes
       const knownScenes = scenes.filter(({ title }) =>


### PR DESCRIPTION
Adds a check when reading in the scenes from the scene folder, and creates the scene folder when creating a new scene, if it's missing.

fix #157 