### PR TITLE
Change the default css classes for Sortable scenes

### DIFF
--- a/src/view/explorer/SceneList.svelte
+++ b/src/view/explorer/SceneList.svelte
@@ -92,7 +92,10 @@
   let isSorting = false;
   const sortableOptions: Sortable.Options = {
     animation: 150,
-    ghostClass: "scene-ghost",
+    ghostClass: "scene-drag-ghost",
+    chosenClass: "scene-drag-chosen",
+    dragClass: "scene-drag-dragging",
+    fallbackClass: "scene-drag-fallback",
     onStart: () => {
       isSorting = true;
     },
@@ -527,7 +530,7 @@
     font-weight: bold;
   }
 
-  :global(.scene-ghost) {
+  :global(.scene-drag-ghost) {
     background-color: var(--interactive-accent-hover);
     color: var(--text-on-accent);
     margin-left: var(--ghost-indent);


### PR DESCRIPTION
By using the default css classes, Sortable.js would create a conflict with other plugins that also used Sortable.js and the default css classes (namely, cMenu).  By using more domain-specific classes, we are less likely to have conflicts in the future.

fix #155 