### PR TITLE
docs: add link to custom-compile-step community repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ You can rename drafts by right-clicking them in the Project tab and selecting Re
 
 The Compile tab allows you to create custom workflows that turn your project into a manuscript. See [COMPILE.md](https://github.com/kevboh/longform/blob/main/docs/COMPILE.md) for more.
 
-### Scene-only Styling
+> [!TIP]
+> You can find more compile steps for various use cases in the [community collection of compile steps](https://github.com/obsidian-community/longform-compile-steps).
+
+## Scene-only Styling
 
 Longform will automatically attach a `.longform-leaf` class to the container panes of any notes that are part of a Longform project. This means you can add custom CSS snippets to Obsidian that style your writing environment and _only_ your writing environment. For example, I prefer a dark theme for Obsidian but a light theme for writing, so my writing snippet looks something like this:
 


### PR DESCRIPTION
https://github.com/obsidian-community/longform-compile-steps

(while I was at it, I also fixed the wrong heading level for the "scene only styling" section below the compile section)