### PR TITLE
wrap scene text

### DIFF
--- a/src/view/explorer/SceneList.svelte
+++ b/src/view/explorer/SceneList.svelte
@@ -357,7 +357,7 @@
     >
       <div
         class="scene-container{item.hidden ? ' hidden' : ''}"
-        style="margin-left: {item.indent * 32}px;"
+        style="padding-left: calc({item.indent} * var(--longform-explorer-indent-size));"
         class:selected={$activeFile && $activeFile.path === item.path}
         on:contextmenu|preventDefault={onContext}
         data-scene-path={item.path}
@@ -466,7 +466,7 @@
     color: var(--text-muted);
     font-size: 1em;
     line-height: 1.1em;
-    white-space: nowrap;
+    white-space: normal;
     padding: var(--size-2-1) 0;
   }
 
@@ -496,7 +496,7 @@
   }
 
   .longform-scene-number::after {
-    content: ":";
+    content: ".";
   }
 
   #longform-unknown-files-wizard {

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,6 @@
 :root {
   --longform-explorer-font-size: var(--font-ui-medium);
+  --longform-explorer-indent-size: 2em;
 }
 
 .longform-settings-user-steps {


### PR DESCRIPTION
fixes some minor css-related issues:
- wrap scene list (use padding instead of margin as the wrapping would overwise result in weird overscroll to the right)
- make the amount of scene indentation a variable so the user / themes can adjust it

before
<img alt="Showcase" width=50% src="https://github.com/kevboh/longform/assets/73286100/99d6cf3a-9b80-4095-a44e-6910ce51e271">

after
<img alt="Showcase" width=50% src="https://github.com/kevboh/longform/assets/73286100/e967ec00-2044-4643-89a6-4e8e0e5e38fb">
