### PR TITLE
feat: use `tab` / `shift-tab` to move in Suggestion Modals

### DIFF
--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -45,14 +45,12 @@ export class JumpModal<T> extends FuzzySuggestModal<string> {
     });
 
     // navigate up/down with Tab and Shift+Tab
-		this.scope.register([], "Tab", (evt: KeyboardEvent): void => {
-			if (evt.isComposing || !this.chooser) return;
-			this.chooser.moveDown(1);
-		});
-		this.scope.register(["Shift"], "Tab", (evt: KeyboardEvent): void => {
-			if (evt.isComposing || !this.chooser) return;
-			this.chooser.moveUp(1);
-		});
+    this.scope.register([], "Tab", (): void => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    });
+    this.scope.register(["Shift"], "Tab", (): void => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
+    });
     instructions.concat([{
       command: "↹ ",
       purpose: "Down",

--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -6,6 +6,17 @@ import {
   type PaneType,
 } from "obsidian";
 
+declare module "obsidian" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- cannot declare otherwise
+	interface FuzzySuggestModal<T> {
+		chooser?: {
+			useSelectedItem: (evt: KeyboardEvent) => boolean;
+			moveDown: (count: number) => void;
+			moveUp: (count: number) => void;
+		};
+	}
+}
+
 export class JumpModal<T> extends FuzzySuggestModal<string> {
   items: Map<string, T>;
   onSelect: (value: T, modEvent: boolean | PaneType) => void;
@@ -32,6 +43,23 @@ export class JumpModal<T> extends FuzzySuggestModal<string> {
       this.close();
       return false;
     });
+
+    // navigate up/down with Tab and Shift+Tab
+		this.scope.register([], "Tab", (evt: KeyboardEvent): void => {
+			if (evt.isComposing || !this.chooser) return;
+			this.chooser.moveDown(1);
+		});
+		this.scope.register(["Shift"], "Tab", (evt: KeyboardEvent): void => {
+			if (evt.isComposing || !this.chooser) return;
+			this.chooser.moveUp(1);
+		});
+    instructions.concat([{
+      command: "↹ ",
+      purpose: "Down",
+    },{
+      command: "↹ ",
+      purpose: "Down",
+    }])
 
     this.setInstructions(instructions);
   }


### PR DESCRIPTION
In addition to arrow keys, you can also use `tab` to move in the suggestion modals, which some people are more used to.