### PR TITLE
feat: create "Add Frontmatter" compile step 

### DIFF
--- a/src/compile/index.ts
+++ b/src/compile/index.ts
@@ -269,7 +269,7 @@ export async function compile(
           },
           context
         );
-        currentInput[0].contents = result;
+        currentInput[0] = result;
       } else {
         currentInput = await step.compile(currentInput, context);
       }

--- a/src/compile/steps/abstract-compile-step.ts
+++ b/src/compile/steps/abstract-compile-step.ts
@@ -38,6 +38,8 @@ export enum CompileStepOptionType {
   Boolean,
   /** A single-line freeform text entry. */
   Text,
+  /** Key-value text */
+  MultilineText,
 }
 
 /**

--- a/src/compile/steps/add-frontmatter.ts
+++ b/src/compile/steps/add-frontmatter.ts
@@ -1,0 +1,35 @@
+import { CompileStepKind, CompileStepOptionType, makeBuiltinStep, type CompileContext, type CompileManuscriptInput } from "./abstract-compile-step";
+
+export const AddFrontmatterStep = makeBuiltinStep({
+    id: "add-frontmatter",
+    description: {
+        name: "Add Frontmatter",
+        description: "Add YAML frontmatter to your manuscript",
+        availableKinds: [CompileStepKind.Manuscript],
+        options: [
+            {
+                id: "frontmatter",
+                name: "Frontmatter",
+                description: "YAML to be added to your manuscript's frontmatter.",
+                type: CompileStepOptionType.MultilineText,
+                default: "",
+            }
+        ]
+    },
+    compile(input: CompileManuscriptInput, context: CompileContext): CompileManuscriptInput {
+        if (context.kind !== CompileStepKind.Manuscript) {
+          throw new Error("Cannot add frontmatter to non-manuscript.");
+        }
+
+        const contents = [
+            "---",
+            context.optionValues["frontmatter"] as string,
+            "---",
+            input.contents,
+        ].join("\n");
+
+        return {
+            contents,
+        }
+    }
+})

--- a/src/compile/steps/index.ts
+++ b/src/compile/steps/index.ts
@@ -5,8 +5,10 @@ import { RemoveLinksStep } from "./remove-links";
 import { RemoveStrikethroughsStep } from "./remove-strikethroughs";
 import { StripFrontmatterStep } from "./strip-frontmatter";
 import { WriteToNoteStep } from "./write-to-note";
+import { AddFrontmatterStep } from "./add-frontmatter";
 
 export const BUILTIN_STEPS = [
+  AddFrontmatterStep,
   ConcatenateTextStep,
   PrependTitleStep,
   RemoveCommentsStep,

--- a/src/view/compile/CompileStepView.svelte
+++ b/src/view/compile/CompileStepView.svelte
@@ -72,6 +72,13 @@
                   placeholder={option.default.replace(/\n/g, "\\n")}
                   bind:value={step.optionValues[option.id]}
                 />
+              {:else if option.type === CompileStepOptionType.MultilineText}
+                <label for={step.id + "-" + option.id}>{option.name}</label>
+                <textarea
+                  id={step.id + "-" + option.id}
+                  placeholder="key: value"
+                  bind:value={step.optionValues[option.id]}
+                />
               {:else}
                 <div class="longform-compile-step-checkbox-container">
                   <input
@@ -194,6 +201,13 @@
     color: var(--text-accent);
     margin: 0 0 var(--size-4-1) 0;
     width: 100%;
+  }
+
+  .longform-compile-step-option textarea {
+    color: var(--text-accent);
+    margin: 0 0 var(--size-4-1) 0;
+    width: 100%;
+    resize: vertical;
   }
 
   .longform-compile-step-option input[type="checkbox"] {


### PR DESCRIPTION
This allows users to add custom frontmatter to their manuscripts during the compile step.

Right now, the implementation uses a textarea element.  I thought doing different input fields for every key value (similar to obsidian's properties view), but that would mean users couldn't use nested structures without resorting to using JSON as a value, which is not pretty.

I also ran into an issue in `src/compile/index.ts` where it would nest a `{ contents: "..." }` object into `{ contents: contents: "..." } }` object.  This caused compilation issues because `contents` was now an object instead of a string.  The fix for that is in this PR too.

I'm open to any feedback or suggested changes you have!

Closes #41 