### PR TITLE
fix: resolve sync issues with optional wait and fallback

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -266,8 +266,13 @@ export default class LongformPlugin extends Plugin {
     });
   }
 
-  private postLayoutInit(): void {
+  private async postLayoutInit(): Promise<void> {
     this.userScriptObserver.beginObserving();
+
+    // Initialize StoreVaultSync with sync awareness
+    await this.storeVaultSync.initialize();
+
+    // Continue with the rest of initialization only after sync is complete
     this.watchProjects();
 
     const defaultToScenes = once(function (d: Draft) {

--- a/src/model/stores.ts
+++ b/src/model/stores.ts
@@ -56,6 +56,11 @@ export const sessions = writable<WordCountSession[]>([]);
  */
 export const draftWordCounts = writable<DraftWordCounts>({});
 
+/**
+ * Writeable store of whether the plugin is waiting for sync.
+ */
+export const waitingForSync = writable<boolean>(false);
+
 // DERIVED STORES
 
 /**

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -95,6 +95,9 @@ export interface LongformPluginSettings {
   sessionFile: string;
   numberScenes: boolean;
   sceneTemplate: string | null;
+  waitForSync: boolean;
+  fallbackWaitEnabled: boolean;
+  fallbackWaitTime: number;
   // DEPRECATED. To be removed in future, needed now for migrations.
   projects: {
     [path: string]: {
@@ -124,6 +127,9 @@ export const DEFAULT_SETTINGS: LongformPluginSettings = {
   numberScenes: false,
   sceneTemplate: null,
   projects: {},
+  waitForSync: false,
+  fallbackWaitEnabled: true,
+  fallbackWaitTime: 5,
 };
 
 export const TRACKED_SETTINGS_PATHS = [
@@ -143,6 +149,9 @@ export const TRACKED_SETTINGS_PATHS = [
   "sessionFile",
   "numberScenes",
   "sceneTemplate",
+  "waitForSync",
+  "fallbackWaitEnabled",
+  "fallbackWaitTime",
 ];
 
 export const PASSTHROUGH_SAVE_SETTINGS_PATHS = [
@@ -158,4 +167,7 @@ export const PASSTHROUGH_SAVE_SETTINGS_PATHS = [
   "sessionFile",
   "numberScenes",
   "sceneTemplate",
+  "waitForSync",
+  "fallbackWaitEnabled",
+  "fallbackWaitTime",
 ];

--- a/src/view/explorer/ExplorerView.svelte
+++ b/src/view/explorer/ExplorerView.svelte
@@ -3,6 +3,7 @@
 
   import { selectedDraft } from "src/model/stores";
   import { selectedTab } from "../stores";
+  import { waitingForSync } from "src/model/stores";
 
   import NewSceneField from "./NewSceneField.svelte";
   import ProjectPicker from "./ProjectPicker.svelte";
@@ -44,6 +45,13 @@
     <button class="longform-migrate-button" type="button" on:click={doMigration}
       >Migrate</button
     >
+  </div>
+{:else if $waitingForSync}
+  <div class="longform-sync-wait">
+    <div class="longform-spinner"></div>
+    <div class="longform-sync-message">
+      Waiting for Obsidian Sync to complete...
+    </div>
   </div>
 {:else}
   <div class="longform-explorer">
@@ -115,5 +123,39 @@
 
   .tab-panel-container {
     padding: 0;
+  }
+
+  .longform-sync-wait {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    padding: 2rem;
+    gap: 1rem;
+  }
+
+  .longform-spinner {
+    border: 3px solid var(--background-modifier-border);
+    border-top: 3px solid var(--text-accent);
+    border-radius: 50%;
+    width: 24px;
+    height: 24px;
+    animation: spin 1s linear infinite;
+  }
+
+  .longform-sync-message {
+    color: var(--text-muted);
+    font-size: 0.8em;
+    text-align: center;
+  }
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
   }
 </style>

--- a/src/view/settings/LongformSettings.ts
+++ b/src/view/settings/LongformSettings.ts
@@ -90,9 +90,8 @@ export class LongformSettingsTab extends PluginSettingTab {
     });
     this.unsubscribeUserScripts = userScriptSteps.subscribe((steps) => {
       if (steps && steps.length > 0) {
-        this.stepsSummary.innerText = `Loaded ${steps.length} step${
-          steps.length !== 1 ? "s" : ""
-        }:`;
+        this.stepsSummary.innerText = `Loaded ${steps.length} step${steps.length !== 1 ? "s" : ""
+          }:`;
       } else {
         this.stepsSummary.innerText = "No steps loaded.";
       }
@@ -255,6 +254,50 @@ export class LongformSettingsTab extends PluginSettingTab {
       sessionFileStorageSettings.settingEl.style.display =
         settings.sessionStorage === "file" ? "flex" : "none";
     });
+
+    new Setting(containerEl).setName("Troubleshooting").setHeading();
+
+    new Setting(containerEl)
+      .setName("Wait for Obsidian Sync")
+      .setDesc("Prevent Longform from running until Obsidian Sync completes its first sync. If you are using Sync, you may want to enable this if you experience issues with scenes disappearing or falsely being shown as new.")
+      .addToggle((cb) => {
+        cb.setValue(settings.waitForSync);
+        cb.onChange((value) => {
+          pluginSettings.update((s) => ({
+            ...s,
+            waitForSync: value,
+          }));
+        });
+      });
+
+    new Setting(containerEl)
+      .setName("Enable fallback wait")
+      .setDesc("If sync status cannot be detected, wait for the time specified below before looking for scenes.")
+      .addToggle((cb) => {
+        cb.setValue(settings.fallbackWaitEnabled);
+        cb.onChange((value) => {
+          pluginSettings.update((s) => ({
+            ...s,
+            fallbackWaitEnabled: value,
+          }));
+        });
+      });
+
+    new Setting(containerEl)
+      .setName("Fallback wait time")
+      .setDesc("Time to wait in seconds if sync status cannot be detected.")
+      .addText((cb) => {
+        cb.setValue(settings.fallbackWaitTime.toString());
+        cb.onChange((value) => {
+          const numberValue = parseInt(value);
+          if (!isNaN(numberValue) && numberValue > 0) {
+            pluginSettings.update((s) => ({
+              ...s,
+              fallbackWaitTime: numberValue,
+            }));
+          }
+        });
+      });
 
     new Setting(containerEl).setName("Credits").setHeading();
 


### PR DESCRIPTION
Regarding issue #212 

Added a check to the internal Obsidian Sync API to see if there is syncing enabled and whether there currently (at Obsidian startup only) is one actively running. If the API ever changes, there's a failsafe that uses a configurable wait time instead.
Interface is blocked by a new loading spinner if a sync is happening.
Config options added as well.

In my testing between a MacBook and a PC, it seems to successfully prevent the index syncing race conditions. Couldn't replicate the bug anymore.

If there's any faux-pas in here, my fullstack-dev days ended around 5 years ago, so I might not know some new conventions. Feel free to change whatever necessary.