### PR TITLE
Filter ignoredFiles before attempting to map them.

### DIFF
--- a/src/model/store-vault-sync.ts
+++ b/src/model/store-vault-sync.ts
@@ -424,7 +424,7 @@ export class StoreVaultSync {
       );
 
       // ignore all new scenes that are known-to-ignore per ignoredFiles
-      const ignoredRegexes = ignoredFiles.map((p) => ignoredPatternToRegex(p));
+      const ignoredRegexes = ignoredFiles.filter(n => n).map((p) => ignoredPatternToRegex(p));
       const unknownFiles = newScenes.filter(
         (s) => ignoredRegexes.find((r) => r.test(s)) === undefined
       );


### PR DESCRIPTION
If the `ignoredFiles` is malformed ([though natural use of the plugin, not through user error](https://github.com/kevboh/longform/issues/289#issuecomment-2724383916)), and is an array filled with any 'empty'/null values, when it runs the subsequent `ignoredPatternToRegex` method, it triggers an exception. This prevents that from happening.

https://github.com/kevboh/longform/issues/289