### PR TITLE
Clarify usage of compile function in COMPILE.md

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -97,6 +97,45 @@ To add a user script to Longform, first create a folder somewhere in your vault 
 Next, add your first step as a `.js` file. Every step must export an object in the following shape:
 
 ```js
+
+compile = (input, context) => {
+  /**
+    Function that is executed during compilation. It may be `async`.
+    Errors encountered during execution should be thrown and will
+    be handled by Longform.
+    @param input If the step is of kind Scene or Join (see context),
+    this will be *an array* containing elements of type:
+      {
+        path: string; // path to scene
+        name: string; // file name of scene
+        contents: string; // text contents of scene
+        metadata: CachedMetadata; // Obsidian metadata of scene
+        indentationLevel?: number; // The indent level (starting at zero) of the scene
+      }
+    where each element corresponds to a scene (and thus the step has access to all scenes at once in `input`).
+    If the step is of kind Manuscript (see context), this will be of type:
+      {
+        // text contents of manuscript
+        contents: string;
+      }
+    @param context The execution context of the step, including the step
+    kind and option values:
+      {
+        kind: string; // "Scene" | "Join" | "Manuscript"
+        optionValues: { [id: string]: unknown } // Map of option IDs to values
+        projectPath: string; // path in vault to compiling project
+        draft: Draft; // The Draft type describing your project
+        app: App; // Obsidian app
+      }
+    @note For an example of using `context` to determine the shape of `input`, see
+    https://github.com/kevboh/longform/blob/main/src/compile/steps/strip-frontmatter.ts
+    @returns If of kind "Scene" or "Manuscript", the same shape as `input`
+    with the appropriate changes made to `contents`. If of kind "Join",
+    the same shape as a "Manuscript" step input.
+  */
+  return;
+}
+
 module.exports = {
   // object that describes the step and its configuration
   description: {
@@ -138,41 +177,6 @@ module.exports = {
       },
     ],
   },
-
-  /**
-    Function that is executed during compilation. It may be `async`.
-    Errors encountered during execution should be thrown and will
-    be handled by Longform.
-    @param input If the step is of kind Scene or Join (see context),
-    this will be *an array* containing elements of type:
-      {
-        path: string; // path to scene
-        name: string; // file name of scene
-        contents: string; // text contents of scene
-        metadata: CachedMetadata; // Obsidian metadata of scene
-        indentationLevel?: number; // The indent level (starting at zero) of the scene
-      }
-    where each element corresponds to a scene (and thus the step has access to all scenes at once in `input`).
-    If the step is of kind Manuscript (see context), this will be of type:
-      {
-        // text contents of manuscript
-        contents: string;
-      }
-    @param context The execution context of the step, including the step
-    kind and option values:
-      {
-        kind: string; // "Scene" | "Join" | "Manuscript"
-        optionValues: { [id: string]: unknown } // Map of option IDs to values
-        projectPath: string; // path in vault to compiling project
-        draft: Draft; // The Draft type describing your project
-        app: App; // Obsidian app
-      }
-    @note For an example of using `context` to determine the shape of `input`, see
-    https://github.com/kevboh/longform/blob/main/src/compile/steps/strip-frontmatter.ts
-    @returns If of kind "Scene" or "Manuscript", the same shape as `input`
-    with the appropriate changes made to `contents`. If of kind "Join",
-    the same shape as a "Manuscript" step input.
-  */
   compile: compile,
 };
 ```


### PR DESCRIPTION
- Make it easier to understand that user need to define his own compile function.
- Make the step work out of the box, the added step appears directly in the "user steps" tab when script is copy pasted into a .js file